### PR TITLE
fix(ci): update dotnet-version from 8.x to 10.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 #      - name: Setup .NET SDK
 #        uses: actions/setup-dotnet@v5
 #        with:
-#          dotnet-version: 8.x
+#          dotnet-version: 10.x
 #
 #      - name: Run Unit Tests
 #        run: dotnet test --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
@@ -58,7 +58,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
       
       # Create the NuGet package in the folder from the environment variable NuGetDirectory
       - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
@@ -79,7 +79,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
       
       # Download the NuGet package created in the previous job
       - uses: actions/download-artifact@v8
@@ -126,7 +126,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
 
       # Publish all NuGet packages to NuGet.org
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.


### PR DESCRIPTION
## Summary

- Updates `dotnet-version` from `8.x` to `10.x` in all 3 workflow jobs (`create_nuget`, `validate_nuget`, `deploy`)
- `global.json` requires SDK `10.0.103` with `rollForward: latestFeature`, but the workflow only installed 8.x
- This caused every CI run to fail with: *"A compatible .NET SDK was not found. Requested SDK version: 10.0.103"*

## Root Cause

Commit `7cd4f74` updated the dotnet monorepo to v10 (including `global.json`) but did not update the CI workflow to install the matching SDK.

## Test plan

- [ ] Verify the PR's own CI run passes (Main Branch CI workflow)
- [ ] Confirm `dotnet pack` succeeds in `create_nuget` job
- [ ] Confirm NuGet validation succeeds in `validate_nuget` job