### PR TITLE
fix: update target framework from net8.0 to net10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <Company>Atypical Consulting SRL</Company>
   </PropertyGroup>
 

--- a/src/FastComponents/FastComponents.csproj
+++ b/src/FastComponents/FastComponents.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>8.0-recommended</AnalysisLevel>
+    <AnalysisLevel>10.0-recommended</AnalysisLevel>
     <AnalysisModeDesign>All</AnalysisModeDesign>
     <AnalysisModeDocumentation>All</AnalysisModeDocumentation>
     <AnalysisModeGlobalization>All</AnalysisModeGlobalization>
@@ -81,10 +81,10 @@
     <Company>Atypical Consulting SRL</Company>
     <Product>FastComponents</Product>
     <Description>
-      Code web, think .NET 8 with FastComponents for a successful MRA (Multiple Resources Application).
+      Code web, think .NET 10 with FastComponents for a successful MRA (Multiple Resources Application).
     </Description>
-    <PackageTags>fastcomponents;mra architecture;core;net8</PackageTags>
-    <Copyright>Copyright (c) 2020-2024 Atypical Consulting SRL</Copyright>
+    <PackageTags>fastcomponents;mra architecture;core;net10</PackageTags>
+    <Copyright>Copyright (c) 2020-2026 Atypical Consulting SRL</Copyright>
     <PackageProjectUrl>https://github.com/Atypical-Consulting/FastComponents</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Atypical-Consulting/FastComponents.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## Summary

- Update `Directory.Build.props` target framework from `net8.0` to `net10.0` (fixes CI build failure)
- Update C# `LangVersion` from `12` to `14` to match .NET 10
- Update `AnalysisLevel` from `8.0-recommended` to `10.0-recommended`
- Update NuGet metadata (description, tags, copyright year) to reflect .NET 10

## Root Cause

CI was failing with:
```
error NU1202: Package Microsoft.AspNetCore.Components.Web 10.0.3 is not compatible with net8.0
```

The shared `Directory.Build.props` still targeted `net8.0` while dependencies (via Renovate) had been upgraded to .NET 10 packages. The `global.json` and workflow already specified .NET 10 SDK.

## Files Changed

| File | Change |
|------|--------|
| `Directory.Build.props` | `TargetFramework` net8.0 → net10.0, `LangVersion` 12 → 14 |
| `src/FastComponents/FastComponents.csproj` | `AnalysisLevel`, description, tags, copyright |

## Test plan

- [ ] CI pipeline passes (dotnet pack succeeds)
- [ ] NuGet package builds correctly for net10.0