### PR TITLE
fix: add build step before NuGet pack in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,13 @@ jobs:
         with:
           dotnet-version: 10.x
       
+      # Build the project first so that staticwebassets.build.json manifest is generated
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
       # Create the NuGet package in the folder from the environment variable NuGetDirectory
-      - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
+      - name: Create NuGet package
+        run: dotnet pack --configuration Release --no-build --output ${{ env.NuGetDirectory }}
       
       # Publish the NuGet package as an artifact, so they can be used in the following jobs
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Add explicit `dotnet build --configuration Release --no-restore` step before `dotnet pack` in the `create_nuget` job
- Add `--no-build` flag to the `dotnet pack` step to avoid double-building
- Fixes the `staticwebassets.build.json` manifest not found error that causes the pack step to fail

## Test plan

- [ ] Verify the `create_nuget` job completes successfully in CI
- [ ] Verify the generated NuGet packages are valid (the `validate_nuget` job passes)