### PR TITLE
fix: add missing dotnet restore step in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           dotnet-version: 10.x
       
+      - name: Restore dependencies
+        run: dotnet restore
+
       # Build the project first so that staticwebassets.build.json manifest is generated
       - name: Build
         run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
## Summary

- Adds a `dotnet restore` step before `dotnet build --no-restore` in the `create_nuget` job
- Fixes `NETSDK1004: Assets file 'project.assets.json' not found` build errors
- Resolves failing run [#22522692678](https://github.com/Atypical-Consulting/FastComponents/actions/runs/22522692678)

## Root Cause

The `create_nuget` job used `dotnet build --configuration Release --no-restore` without a preceding `dotnet restore` step, so NuGet packages were never restored and the build failed.

## Test plan

- [ ] CI passes on this PR (create_nuget job succeeds)
- [ ] NuGet package artifact is created successfully