### PR TITLE
Integrate TheAppManager module system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.14" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageVersion Include="TheAppManager" Version="2.0.0" />
   </ItemGroup>
   <!-- Development Tools -->
   <ItemGroup>
@@ -20,7 +21,7 @@
   <!-- Source Generators -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0-2.25625.1" />
   </ItemGroup>
   <!-- Testing Dependencies -->
   <ItemGroup>

--- a/demo/HtmxAppServer/HtmxAppServer.csproj
+++ b/demo/HtmxAppServer/HtmxAppServer.csproj
@@ -21,9 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\FastComponents.Generators\FastComponents.Generators.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\src\FastComponents.Generators\FastComponents.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TheAppManager" />
   </ItemGroup>
 
 </Project>

--- a/demo/HtmxAppServer/Modules/EndpointsModule.cs
+++ b/demo/HtmxAppServer/Modules/EndpointsModule.cs
@@ -1,0 +1,39 @@
+using HtmxAppServer.Components;
+using HtmxAppServer.Components.Blocks;
+using TheAppManager.Modules;
+using static HtmxAppServer.Components.HtmxRoutes;
+
+namespace HtmxAppServer.Modules;
+
+/// <summary>
+/// Configures HTMX endpoint routes for the application.
+/// </summary>
+public class EndpointsModule : IAppModule
+{
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        // Map HTMX endpoints using convention-based registration
+        // This single line replaces ~15 manual MapHtmxGet/MapHtmxPost calls for example components
+#pragma warning disable IL2026, IL3050 // HTMX endpoints require reflection and dynamic code
+        app.UseFastComponentsAuto(
+            routePrefix: "/ui/examples",
+            predicate: t => t.Name.EndsWith("Example", StringComparison.Ordinal),
+            typeof(CounterExample).Assembly);
+#pragma warning restore IL2026, IL3050
+    }
+
+    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        // Explicitly register components that don't follow the convention pattern
+#pragma warning disable IL2026, IL3050 // HTMX endpoints require reflection and dynamic code
+        endpoints.MapHtmxGet<App, AppParameters>(RouteApp)
+            .AllowAnonymous();
+
+        endpoints.MapHtmxGet<ExamplesDashboard>(RouteExamples)
+            .AllowAnonymous();
+
+        endpoints.MapHtmxGet<DebugDashboard, DebugDashboardParameters>(RouteDebug)
+            .AllowAnonymous();
+#pragma warning restore IL2026, IL3050
+    }
+}

--- a/demo/HtmxAppServer/Modules/MiddlewareModule.cs
+++ b/demo/HtmxAppServer/Modules/MiddlewareModule.cs
@@ -1,0 +1,19 @@
+using HtmxAppServer.Middleware;
+using TheAppManager.Modules;
+
+namespace HtmxAppServer.Modules;
+
+/// <summary>
+/// Configures the HTTP middleware pipeline for the HTMX application.
+/// </summary>
+public class MiddlewareModule : IAppModule
+{
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        app.UseHttpsRedirection();
+        app.UseStaticFiles();
+
+        // Add HTMX debugging middleware
+        app.UseMiddleware<HtmxDebuggingMiddleware>();
+    }
+}

--- a/demo/HtmxAppServer/Modules/ServicesModule.cs
+++ b/demo/HtmxAppServer/Modules/ServicesModule.cs
@@ -1,0 +1,28 @@
+using HtmxAppServer.Services;
+using TheAppManager.Modules;
+
+namespace HtmxAppServer.Modules;
+
+/// <summary>
+/// Configures dependency injection services for the HTMX application.
+/// </summary>
+public class ServicesModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        IServiceCollection services = builder.Services;
+
+        // Configure JSON serialization for AOT
+        services.ConfigureHttpJsonOptions(options =>
+            options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default));
+
+        // Add FastComponents services (auto mode includes core services)
+        services.AddFastComponentsAuto();
+
+        // Add business services
+        services.AddSingleton<MovieService>();
+
+        // Add debugging services
+        services.AddSingleton<HtmxRequestTracker>();
+    }
+}

--- a/demo/HtmxAppServer/Program.cs
+++ b/demo/HtmxAppServer/Program.cs
@@ -1,52 +1,15 @@
 global using FastComponents;
 global using static HtmxAppServer.Components.HtmxRoutes;
 
-using HtmxAppServer;
-using HtmxAppServer.Components;
-using HtmxAppServer.Components.Blocks;
-using HtmxAppServer.Services;
-using HtmxAppServer.Middleware;
+using HtmxAppServer.Modules;
+using TheAppManager.Startup;
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-IServiceCollection services = builder.Services;
-
-// Configure JSON serialization for AOT
-services.ConfigureHttpJsonOptions(options => options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default));
-
-// Add FastComponents services (auto mode includes core services)
-services.AddFastComponentsAuto();
-
-// Add business services
-services.AddSingleton<MovieService>();
-
-// Add debugging services
-services.AddSingleton<HtmxRequestTracker>();
-
-WebApplication app = builder.Build();
-
-app.UseHttpsRedirection();
-app.UseStaticFiles();
-
-// Add HTMX debugging middleware
-app.UseMiddleware<HtmxDebuggingMiddleware>();
-
-// Map HTMX endpoints using convention-based registration
-// This single line replaces ~15 manual MapHtmxGet/MapHtmxPost calls for example components
-#pragma warning disable IL2026, IL3050 // HTMX endpoints require reflection and dynamic code
-app.UseFastComponentsAuto(
-    routePrefix: "/ui/examples",
-    predicate: t => t.Name.EndsWith("Example", StringComparison.Ordinal),
-    typeof(CounterExample).Assembly);
-
-// Explicitly register components that don't follow the convention pattern
-app.MapHtmxGet<App, AppParameters>(RouteApp)
-    .AllowAnonymous();
-
-app.MapHtmxGet<ExamplesDashboard>(RouteExamples)
-    .AllowAnonymous();
-
-app.MapHtmxGet<DebugDashboard, DebugDashboardParameters>(RouteDebug)
-    .AllowAnonymous();
-#pragma warning restore IL2026, IL3050
-
-app.Run();
+AppManager.Start(
+    args,
+    modules =>
+    {
+        modules
+            .Add<ServicesModule>()
+            .Add<MiddlewareModule>()
+            .Add<EndpointsModule>();
+    });


### PR DESCRIPTION
## Summary
- Add `TheAppManager` 2.0.0 NuGet package to the demo web project
- Refactor `Program.cs` to use `AppManager.Start()` with three composable modules:
  - **ServicesModule** — DI registrations (JSON serialization, FastComponents, MovieService, HtmxRequestTracker)
  - **MiddlewareModule** — HTTP pipeline (HTTPS redirection, static files, HTMX debugging middleware)
  - **EndpointsModule** — HTMX route mappings (convention-based auto-registration and explicit component endpoints)
- Fix pre-existing `Microsoft.CodeAnalysis.Analyzers` version mismatch in `Directory.Packages.props`

All existing service registrations, middleware, and endpoint mappings are preserved with no business logic changes.

## Test plan
- [x] Solution builds successfully (`dotnet build`)
- [x] All 257 tests pass (`dotnet test`: 202 unit tests + 55 generator tests)
- [ ] Verify the demo app runs correctly with `dotnet run --project demo/HtmxAppServer`
- [ ] Confirm all HTMX routes respond as before (counter, movie characters, debug dashboard)