### PR TITLE
ci: run the build on pull requests to the default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,6 @@ on:
     branches:
       - "main"       # Trigger the workflow on pushes to the main branch
   pull_request:
-    branches:
-      - "main"       # Trigger the workflow on pull requests to the main branch
   release:
     types:
       - published    # Run the workflow when a new GitHub release is published

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <!-- Runtime Dependencies -->
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.4.0" />
+    <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.14" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageVersion Include="TheAppManager" Version="2.0.0" />


### PR DESCRIPTION
### La CI de ce depot ne s'executait sur aucune pull request

La branche par defaut est **`dev`**, mais `main.yml` filtrait ses PR sur `- "main" # Trigger the workflow on pull requests to the main branch`.

GitHub n'evalue le declencheur `pull_request` que si la branche **cible** correspond au filtre : aucune PR vers la branche par defaut ne declenchait donc de build. Consequences mesurees :

- aucun check ne gardait les merges sur ce depot ;
- l'automerge Renovate ne pouvait jamais s'armer (il attend un check vert), d'ou l'accumulation de PR.

Le filtre de branche est retire de `pull_request` (convention du portfolio : une PR vers n'importe quelle branche declenche le build). **`push` est laisse intact** : le repointer ferait tourner la CI sur la branche par defaut, ou un echec preexistant s'afficherait en rouge.

Cette PR est son propre test : le check qui apparait ci-dessous est la preuve que le declencheur fonctionne. Merge uniquement s'il est vert.