### PR TITLE
ci: publish to NuGet via Trusted Publishing, not a long-lived key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,13 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: [ validate_nuget, run_test ]
+
+    # Job-level, so it must restate contents: read — a job-level block REPLACES the
+    # workflow-level one rather than adding to it.
+    permissions:
+      contents: read
+      id-token: write # request the GitHub OIDC token for NuGet Trusted Publishing
+
     steps:
       # Download the NuGet package created in the previous job
       - uses: actions/download-artifact@v8
@@ -140,8 +147,21 @@ jobs:
       # Publish all NuGet packages to NuGet.org
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.
       # If you retry a failed workflow, already published packages will be skipped without error.
+      # Trusted Publishing: exchanges the OIDC token (needs `id-token: write` above) for a NuGet
+      # key valid ~1 hour, so no long-lived secret is stored. Keep it adjacent to the push so the
+      # key cannot expire in between. Requires a Trusted Publishing policy on nuget.org naming
+      # this repository and `main.yml`, plus the NUGET_USER secret (the nuget.org profile name).
+      # Deliberately UNGUARDED: this job only runs on a published Release, so publishing is
+      # expected. A missing policy must fail loudly rather than skip and leave the release
+      # unpublished behind a green check.
+      - name: NuGet login (OIDC -> short-lived key)
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish NuGet package
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+              dotnet nuget push $file --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
           }


### PR DESCRIPTION
## The defect

This repo's publish step guarded on `secrets.NUGET_API_KEY`. Several workflows in this org carry a
comment saying that secret is absent, so the push is "a clean no-op". That was checked with
`gh secret list`, **which reports repository secrets only.**

Measured against the API instead:

| probe | result |
|---|---|
| `actions/organization-secrets` | **1 — `NUGET_API_KEY`, created 2026-02-28** |
| `actions/secrets` (repo) | 0 |
| `actions/variables` · `organization-variables` | 0 · 0 |

The key resolved. The push was **live**, not inert.

## The change

Trusted Publishing (OIDC): the login step exchanges the GitHub OIDC token for a key valid ~1 h, so
no long-lived secret is stored anywhere. `NuGet/login` is pinned by digest and kept adjacent to the
push so the key cannot expire in between.

Two details that are easy to get wrong:

- **The job-level `permissions:` block restates what the workflow-level one granted.** A job-level
  block *replaces* the workflow-level one rather than adding to it — omitting `contents` would have
  broken the GitHub Release steps.
- **The login step is deliberately unguarded.** This job only runs on a release trigger, so
  publishing is expected: a missing policy must fail *loudly* rather than skip and leave a tagged
  version unpublished behind a green check. Pattern taken from
  [`RoselineMCP#114`](https://github.com/Atypical-Consulting/RoselineMCP/pull/114), whose argument
  is better than a silent no-op here.

## ⚠️ Do not merge before doing this, in this order

1. **Create the Trusted Publishing policy on nuget.org**, under the account that **owns** the
   package id, naming this repository and **this exact workflow file**.
2. **Set the `NUGET_USER` secret** — the nuget.org profile name, not a credential.
3. **Cut one real release** and confirm the package appears on the flatcontainer index.
4. **Only then delete `NUGET_API_KEY`.**

Deleting the key first leaves no way back if the policy is wrong. Merging before step 1 means the
next tag fails — loudly, by design, but it fails.

Full procedure and the portfolio-wide worklist: `repo-audit/TRUSTED_PUBLISHING.md`.
